### PR TITLE
fixes for new version of hardhat

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hardhat-change-network",
-  "version": "0.0.7",
+  "version": "0.1.0",
   "description": "Hardhat TypeScript plugin boilerplate",
   "repository": "github:dmihal/hardhat-change-network",
   "author": "David Mihal",
@@ -32,7 +32,7 @@
     "@types/mocha": "^5.2.6",
     "@types/node": "^8.10.38",
     "chai": "^4.2.0",
-    "hardhat": "^2.0.0",
+    "hardhat": "^2.19.0",
     "mocha": "^7.1.2",
     "prettier": "2.0.5",
     "ts-node": "^8.1.0",
@@ -42,6 +42,6 @@
     "typescript": "^4.0.3"
   },
   "peerDependencies": {
-    "hardhat": "^2.0.0"
+    "hardhat": "^2.19.0"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,19 +13,18 @@ extendEnvironment((hre) => {
   // needed.
   const providers: { [name: string]: EthereumProvider } = {};
 
-  hre.getProvider = function getProvider(name: string): EthereumProvider {
+  hre.getProvider = async function getProvider(name: string): Promise<EthereumProvider> {
     if (!providers[name]) {
-      providers[name] = createProvider(
+      providers[name] = await createProvider(
+        this.config,
         name,
-        this.config.networks[name],
-        this.config.paths,
         this.artifacts,
       );
     }
     return providers[name];
   };
 
-  hre.changeNetwork = function changeNetwork(newNetwork: string) {
+  hre.changeNetwork = async function changeNetwork(newNetwork: string) {
     if (!this.config.networks[newNetwork]) {
       throw new Error(`changeNetwork: Couldn't find network '${newNetwork}'`);
     }
@@ -36,11 +35,14 @@ extendEnvironment((hre) => {
 
     this.network.name = newNetwork;
     this.network.config = this.config.networks[newNetwork];
-    this.network.provider = this.getProvider(newNetwork);
+    this.network.provider = await this.getProvider(newNetwork);
 
     if ((this as any).ethers) {
-      const { EthersProviderWrapper } = require("@nomiclabs/hardhat-ethers/internal/ethers-provider-wrapper");
-      (this as any).ethers.provider = new EthersProviderWrapper(this.network.provider);
+      const { HardhatEthersProvider } = require("@nomicfoundation/hardhat-ethers/internal/hardhat-ethers-provider");
+      (this as any).ethers.provider = new HardhatEthersProvider(
+        this.network.provider,
+        this.network.name
+      );
     }
   };
 });

--- a/src/type-extensions.ts
+++ b/src/type-extensions.ts
@@ -9,7 +9,7 @@ declare module "hardhat/types/runtime" {
   // This is an example of an extension to the Hardhat Runtime Environment.
   // This new field will be available in tasks' actions, scripts, and tests.
   export interface HardhatRuntimeEnvironment {
-    changeNetwork(newNetwork: string): void;
-    getProvider(newNetwork: string): EthereumProvider;
+    changeNetwork(newNetwork: string): Promise<void>;
+    getProvider(newNetwork: string): Promise<EthereumProvider>;
   }
 }


### PR DESCRIPTION
Fixes for new hardhat version (^2.19.0)

- Now functions async (because its uses async functions from hardhat)
- Fixed ethers import path
- Version bumped